### PR TITLE
add Dockerfile to RED_HAWK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:7.4-cli
+RUN apt-get update && apt-get install -y git
+RUN git clone https://github.com/Tuhinshubhra/RED_HAWK && cp -r RED_HAWK /usr/src/redhawk
+WORKDIR /usr/src/redhawk
+CMD [ "php", "./rhawk.php", "<<<","$'fix'" ]
+CMD [ "php", "./rhawk.php", "<<<","$'update'" ]
+CMD [ "php", "./rhawk.php" ]


### PR DESCRIPTION
Add Dockerfile for the project (Docker version #27)

Just build and run: 
```sh
docker build -t redhawk .
docker run -it --rm redhawk
```
or pull it from [dockerhub](https://hub.docker.com/repository/docker/fractalizers/redhawk) :
```sh
docker pull fractalizers/redhawk:latest
docker run -it --rm redhawk
```

Hope it can be useful !